### PR TITLE
Add localised links to EFF privacy guides

### DIFF
--- a/translations/es.md
+++ b/translations/es.md
@@ -26,7 +26,7 @@ layout: default
 -----
 
 ### Próximos pasos
-¿Quiere tomar medidas para protegerse? Siga [esta](https://ssd.eff.org/) guía de la Fundación Frontera Electrónica.
+¿Quiere tomar medidas para protegerse? Siga [esta](https://ssd.eff.org/es) guía de la Fundación Frontera Electrónica.
 
 -----
 Spanish translation by [SparklezMadeMe](https://www.reddit.com/r/translator/comments/752qcf/english_any_translating_whyprivacymattersorg_a/do31tbt/), little improvements by [xavrb](https://github.com/xavrb)

--- a/translations/fr.md
+++ b/translations/fr.md
@@ -26,7 +26,7 @@ layout: default
 -----
 
 ### Étape suivante
-Vous voulez prendre des mesures pour vous protéger ? Suivez [ce guide](https://ssd.eff.org/) de l'Electronic Frontier Foundation.
+Vous voulez prendre des mesures pour vous protéger ? Suivez [ce guide](https://ssd.eff.org/fr) de l'Electronic Frontier Foundation.
 
 -----
 French translation by [Oxodao](https://github.com/milesmcc/whyprivacymatters/pull/4/commits/a9bd1f228e279ba2d067c94bdd89b756bf59dabb)

--- a/translations/pt.md
+++ b/translations/pt.md
@@ -26,7 +26,7 @@ layout: default
 -----
 
 ### Próximos passos
-Quer tomar medidas para se proteger? Siga [este](https://ssd.eff.org/) guia pela Electronic Frontier Foundation.
+Quer tomar medidas para se proteger? Siga [este](https://ssd.eff.org/pt-br) guia pela Electronic Frontier Foundation.
 
 -----
 Portuguese translation by [Nekiga](https://www.reddit.com/r/translator/comments/752qcf/english_any_translating_whyprivacymattersorg_a/do2zvbr/).

--- a/translations/ru.md
+++ b/translations/ru.md
@@ -25,7 +25,7 @@ title: Почему ваша конфиденциальность важна
 -----
 
 ### Следующие шаги
-Хотите узнать, что делать дальше, чтобы обезопасить себя? Прочитайте [это](https://ssd.eff.org/) руководство от Electronic Frontier Foundation.
+Хотите узнать, что делать дальше, чтобы обезопасить себя? Прочитайте [это](https://ssd.eff.org/ru) руководство от Electronic Frontier Foundation.
 
 -----
 Russian translation by [ibarakaiev](https://github.com/ibarakaiev).


### PR DESCRIPTION
This PR adds the available EFF guide localised links to the appropriate translations.

Closes #20 