### PR TITLE
Fixed repository link issue on the website using jekyll-github-metadata

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 gem 'jekyll'
 gem 'jekyll-sitemap', group: :jekyll_plugins
 gem 'jekyll-seo-tag', group: :jekyll_plugins
-gem 'jekyll-github-metadata', group: :jekyll_plugins
+gem 'jekyll-github-metadata'

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 gem 'jekyll'
 gem 'jekyll-sitemap', group: :jekyll_plugins
 gem 'jekyll-seo-tag', group: :jekyll_plugins
+gem 'jekyll-github-metadata', group: :jekyll_plugins

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 gem 'jekyll'
 gem 'jekyll-sitemap', group: :jekyll_plugins
 gem 'jekyll-seo-tag', group: :jekyll_plugins
-gem 'jekyll-github-metadata'
+gem 'jekyll-github-metadata', group: :jekyll_plugins

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,11 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
+    eventmachine (1.2.7-x64-mingw32)
+    faraday (1.0.1)
+      multipart-post (>= 1.2, < 3)
     ffi (1.13.1)
+    ffi (1.13.1-x64-mingw32)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
     i18n (1.8.5)
@@ -29,6 +33,9 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 1.8)
+    jekyll-github-metadata (2.13.0)
+      jekyll (>= 3.4, < 5.0)
+      octokit (~> 4.0, != 4.4.0)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
     jekyll-seo-tag (2.6.1)
@@ -46,6 +53,10 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
+    multipart-post (2.1.1)
+    octokit (4.18.0)
+      faraday (>= 0.9)
+      sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.6)
@@ -57,15 +68,22 @@ GEM
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
+    sassc (2.4.0-x64-mingw32)
+      ffi (~> 1.9)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     unicode-display_width (1.7.0)
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   jekyll
+  jekyll-github-metadata
   jekyll-seo-tag
   jekyll-sitemap
 

--- a/_config.yml
+++ b/_config.yml
@@ -4,10 +4,12 @@ logo: assets/icon.png
 description: Privacy is important. Here are some simple reasons why.
 url: https://whyprivacymatters.org
 lang: en
+repository: milesmcc/whyprivacymatters
 
 plugins:
 - jekyll-seo-tag
 - jekyll-sitemap
+- jekyll-github-metadata
 
 # Build Settings
 permalink: :title/


### PR DESCRIPTION
Addresses #26 by adding the `jekyll-github-metadata` plugin to use the `site.github` namespace in `_includes/footer.html`.